### PR TITLE
Only put the password to the first response (factor).

### DIFF
--- a/ngx_http_authnz_pam_module.c
+++ b/ngx_http_authnz_pam_module.c
@@ -190,8 +190,15 @@ static int ngx_auth_pam_conv(int num_msg, const struct pam_message ** msg, struc
     {
         response[i].resp = 0;
         response[i].resp_retcode = 0;
-        if (msg[i]->msg_style == PAM_PROMPT_ECHO_OFF) 
-            response[i].resp = strdup(appdata_ptr);
+        if (msg[i]->msg_style == PAM_PROMPT_ECHO_OFF) {
+            if (i == 0) {
+                response[i].resp = strdup(appdata_ptr);
+            }
+            else
+            {
+                response[i].resp = NULL;
+            }
+        }
         else 
         {
             free(response);


### PR DESCRIPTION
When modules start to support pre-auth, we would put the password+code
(in case of OTP setup) to both first and second factor, leading to
PAM_CRED_ERR / Failure setting user credentials.

Port of mod_authnz_pam commit 6de21466287c3e77850ab1d66f076405971ba4f3.
